### PR TITLE
feat: generate extra rows at runtime based on enabled mods

### DIFF
--- a/include/Megamix/Hooks.hpp
+++ b/include/Megamix/Hooks.hpp
@@ -1,11 +1,16 @@
 #ifndef MEGAMIX_HOOKS_H
 #define MEGAMIX_HOOKS_H
 
+#include "types.h"
+
 namespace Megamix::Hooks {
     void TickflowHooks();
     void TempoHooks();
     void RegionHooks();
     void DisableAllHooks();
+
+    template<typename T> T StubbedFunction();
+    template<typename T> void StubFunction(u32 address);
 }
 
 #endif

--- a/include/Megamix/Region.hpp
+++ b/include/Megamix/Region.hpp
@@ -27,6 +27,7 @@ namespace Region {
 
     std::vector<u32> MuseumRowsInfoAddresses();
     std::vector<u32> MuseumRowsColorsAddresses();
+    u32              MuseumRowsColorsInitFunc();
     // TODO: maybe make this into MuseumRowsCmps that returns a
     // map of int -> vector<u8> other regions might use different registers
     std::vector<u32> MuseumRowsR1Cmps();

--- a/include/Megamix/Types.hpp
+++ b/include/Megamix/Types.hpp
@@ -186,7 +186,9 @@ namespace Megamix {
         u32 lowIndex;
 
         MuseumRow(std::array<u16, 5> gameIndices, const char *titleId, u32 highIndex, u32 lowIndex) {
-            if      (gameIndices[1] == 0x101) this->columnCount = 1;
+            if      (gameIndices[0] == 0x101) this->columnCount = 0;
+            else if (gameIndices[1] == 0x101) this->columnCount = 1;
+            else if (gameIndices[2] == 0x101) this->columnCount = 2;
             else if (gameIndices[3] == 0x101) this->columnCount = 3;
             else if (gameIndices[4] == 0x101) this->columnCount = 4;
             else                              this->columnCount = 5;

--- a/include/Megamix/Types.hpp
+++ b/include/Megamix/Types.hpp
@@ -203,6 +203,27 @@ namespace Megamix {
         u8 g;
         u8 b;
         u8 a;
+
+        Color8() {
+            this->r = 0;
+            this->g = 0;
+            this->b = 0;
+            this->a = 0;
+        }
+
+        Color8(u8 r, u8 g, u8 b, u8 a) {
+            this->r = r;
+            this->g = g;
+            this->b = b;
+            this->a = a;
+        }
+
+        Color8(u32 color) {
+            this->r = color >> 24;
+            this->g = color >> 16;
+            this->b = color >>  8;
+            this->a = color;
+        }
     };
 
     struct MuseumRowColor {

--- a/src/Megamix/Hooks.cpp
+++ b/src/Megamix/Hooks.cpp
@@ -18,7 +18,7 @@ namespace Megamix::Hooks {
     RT_HOOK tempoStrmHook;
     RT_HOOK tempoSeqHook;
     RT_HOOK tempoAllHook;
-    
+
     RT_HOOK regionFSHook;
     RT_HOOK regionOtherHook;
 
@@ -142,4 +142,27 @@ namespace Megamix::Hooks {
         rtDisableHook(&regionFSHook);
         rtDisableHook(&regionOtherHook);
     }
+
+    template<typename T>
+    T StubbedFunction() {
+        return {};
+    }
+
+    template<>
+    void StubbedFunction<void>() {
+    }
+
+    // redirects function at address to a stubbed function
+    template<typename T>
+    void StubFunction(u32 address) {
+        rtGenerateJumpCode(
+            (u32)   StubbedFunction<T>,
+            (u32 *) address
+        );
+    }
+
+    // template instantiations
+    // if either StubbedFunction or StubFunction is used with a type, a template
+    // instantiation must be added with that type
+    template void StubFunction<void>(u32);
 }

--- a/src/Megamix/Patches.cpp
+++ b/src/Megamix/Patches.cpp
@@ -1,4 +1,6 @@
 #include <array>
+#include <vector>
+#include <algorithm>
 
 #include <3ds.h>
 #include <CTRPluginFramework.hpp>
@@ -126,6 +128,8 @@ namespace Megamix::Patches {
                 PushExtraRow(newRowIds);
             }
         }
+
+        std::reverse(extraMuseumRows.begin(), extraMuseumRows.end());
 
         // concat extra rows with original rows
         std::vector<MuseumRow> originalMuseumRows = std::move(museumRows);

--- a/src/Megamix/Patches.cpp
+++ b/src/Megamix/Patches.cpp
@@ -156,8 +156,8 @@ namespace Megamix::Patches {
             Process::Patch(address, compare_r8_instruction);
         }
 
-        // FIXME: for this to work we need to stop c++ from overwriting the
-        // colors when it runs the constructor (@ 0x38DE58) for the array
+        Process::Patch(Region::MuseumRowsColorsInitFunc(), /* bx lr */ 0xe12fff1e);
+
         for (auto address : Region::MuseumRowsColorsAddresses()) {
             Process::Patch(address, (u32) museumRowColors.data());
         }

--- a/src/Megamix/Patches.cpp
+++ b/src/Megamix/Patches.cpp
@@ -5,6 +5,7 @@
 
 #include "Megamix.hpp"
 #include "Config.hpp"
+#include "external/rt.h"
 
 namespace Megamix::Patches {
     std::vector<MuseumRow> museumRows {
@@ -148,6 +149,17 @@ namespace Megamix::Patches {
         );
     }
 
+    void StubbedFunction() {
+    }
+
+    // redirects function at address to a stubbed function
+    void StubFunction(u32 address) {
+        rtGenerateJumpCode(
+            (u32)   StubbedFunction,
+            (u32 *) address
+        );
+    }
+
     void PatchMuseumExtraRows() {
         AddExtraRowsToFront();
 
@@ -170,7 +182,7 @@ namespace Megamix::Patches {
             Process::Patch(address, compare_r8_instruction);
         }
 
-        Process::Patch(Region::MuseumRowsColorsInitFunc(), /* bx lr */ 0xe12fff1e);
+        StubFunction(Region::MuseumRowsColorsInitFunc());
 
         for (auto address : Region::MuseumRowsColorsAddresses()) {
             Process::Patch(address, (u32) museumRowColors.data());

--- a/src/Megamix/Patches.cpp
+++ b/src/Megamix/Patches.cpp
@@ -5,7 +5,6 @@
 
 #include "Megamix.hpp"
 #include "Config.hpp"
-#include "external/rt.h"
 
 namespace Megamix::Patches {
     std::vector<MuseumRow> museumRows {
@@ -149,17 +148,6 @@ namespace Megamix::Patches {
         );
     }
 
-    void StubbedFunction() {
-    }
-
-    // redirects function at address to a stubbed function
-    void StubFunction(u32 address) {
-        rtGenerateJumpCode(
-            (u32)   StubbedFunction,
-            (u32 *) address
-        );
-    }
-
     void PatchMuseumExtraRows() {
         AddExtraRowsToFront();
 
@@ -182,7 +170,7 @@ namespace Megamix::Patches {
             Process::Patch(address, compare_r8_instruction);
         }
 
-        StubFunction(Region::MuseumRowsColorsInitFunc());
+        Hooks::StubFunction<void>(Region::MuseumRowsColorsInitFunc());
 
         for (auto address : Region::MuseumRowsColorsAddresses()) {
             Process::Patch(address, (u32) museumRowColors.data());

--- a/src/Megamix/Patches.cpp
+++ b/src/Megamix/Patches.cpp
@@ -94,10 +94,10 @@ namespace Megamix::Patches {
         // museum don't support rows with only 2 games
         if (config->tickflows.size() == 2) {
             for (auto &pair : config->tickflows) {
-                PushExtraRow({ pair.first, 0x101, 0x101, 0x101, 0x101 });
+                PushExtraRow({ pair.first, None, None, None, None });
             }
         } else {
-            std::array<u16, 5> newRowIds { 0x101, 0x101, 0x101, 0x101, 0x101 };
+            std::array<u16, 5> newRowIds { None, None, None, None, None };
             size_t newRowLength = 0;
 
             for (auto &pair : config->tickflows) {
@@ -107,7 +107,7 @@ namespace Megamix::Patches {
                 if (newRowLength == 5) {
                     PushExtraRow(newRowIds);
 
-                    newRowIds = { 0x101, 0x101, 0x101, 0x101, 0x101 };
+                    newRowIds = { None, None, None, None, None };
                     newRowLength = 0;
                 }
             }
@@ -119,7 +119,7 @@ namespace Megamix::Patches {
                 newRowIds[2] = last_extra_row.gameIndices[4];
 
                 last_extra_row.columnCount -= 1;
-                last_extra_row.gameIndices[4] = 0x101;
+                last_extra_row.gameIndices[4] = None;
             }
 
             if (newRowLength != 0) {

--- a/src/Megamix/Patches.cpp
+++ b/src/Megamix/Patches.cpp
@@ -6,8 +6,6 @@
 #include "Megamix.hpp"
 #include "Config.hpp"
 
-#define rgba(value) Color8 { (value >> 24) & 0xff, (value >> 16) & 0xff, (value >> 8) & 0xff, value & 0xff }
-
 namespace Megamix::Patches {
     std::vector<MuseumRow> museumRows {
         /* 0  */ MuseumRow({ RvlKarate0,     NtrRobotS,     RvlBadmintonS, CtrStepS,        None       }, "stage_gr00",    0, 0),
@@ -42,35 +40,35 @@ namespace Megamix::Patches {
     };
 
     std::vector<MuseumRowColor> museumRowColors {
-        /* 0  */ MuseumRowColor(rgba(0xFFED2AFF), rgba(0x8C640000)),
-        /* 1  */ MuseumRowColor(rgba(0x4AF8F1FF), rgba(0x01494C00)),
-        /* 2  */ MuseumRowColor(rgba(0xDCD9D9FF), rgba(0x85561600)),
-        /* 3  */ MuseumRowColor(rgba(0xFFA030FF), rgba(0x783A0000)),
-        /* 4  */ MuseumRowColor(rgba(0x3667CAFF), rgba(0x04007800)),
-        /* 5  */ MuseumRowColor(rgba(0xCECACAFF), rgba(0x82393900)),
-        /* 6  */ MuseumRowColor(rgba(0xEB4040FF), rgba(0x4F000000)),
-        /* 7  */ MuseumRowColor(rgba(0x9A43B7FF), rgba(0x0F013F00)),
-        /* 8  */ MuseumRowColor(rgba(0xAFAFAFFF), rgba(0x284D2F00)),
-        /* 9  */ MuseumRowColor(rgba(0x2BA820FF), rgba(0x013F0D00)),
-        /* 10 */ MuseumRowColor(rgba(0x2BA820FF), rgba(0x013F0D00)),
-        /* 11 */ MuseumRowColor(rgba(0x2BA820FF), rgba(0x013F0D00)),
-        /* 12 */ MuseumRowColor(rgba(0x2BA820FF), rgba(0x013F0D00)),
-        /* 13 */ MuseumRowColor(rgba(0x2BA820FF), rgba(0x013F0D00)),
-        /* 14 */ MuseumRowColor(rgba(0x2BA820FF), rgba(0x013F0D00)),
-        /* 15 */ MuseumRowColor(rgba(0x2BA820FF), rgba(0x013F0D00)),
-        /* 16 */ MuseumRowColor(rgba(0xFFCAEDFF), rgba(0x7E3E9200)),
-        /* 17 */ MuseumRowColor(rgba(0xB7ECE2FF), rgba(0x2E818600)),
-        /* 18 */ MuseumRowColor(rgba(0xECE5B7FF), rgba(0xADAA0800)),
-        /* 19 */ MuseumRowColor(rgba(0x8C8C8CFF), rgba(0x503C5000)),
-        /* 20 */ MuseumRowColor(rgba(0xF7F2B9FF), rgba(0xAA943C00)),
-        /* 21 */ MuseumRowColor(rgba(0xF7F2B9FF), rgba(0xAA943C00)),
-        /* 22 */ MuseumRowColor(rgba(0xF7F2B9FF), rgba(0xAA943C00)),
-        /* 23 */ MuseumRowColor(rgba(0x78500AFF), rgba(0x643C3200)),
-        /* 24 */ MuseumRowColor(rgba(0x78500AFF), rgba(0x643C3200)),
-        /* 25 */ MuseumRowColor(rgba(0x78500AFF), rgba(0x643C3200)),
-        /* 26 */ MuseumRowColor(rgba(0x78500AFF), rgba(0x643C3200)),
-        /* 27 */ MuseumRowColor(rgba(0x78500AFF), rgba(0x643C3200)),
-        /* 28 */ MuseumRowColor(rgba(0x78500AFF), rgba(0x643C3200)),
+        /* 0  */ MuseumRowColor(0xFFED2AFF, 0x8C640000),
+        /* 1  */ MuseumRowColor(0x4AF8F1FF, 0x01494C00),
+        /* 2  */ MuseumRowColor(0xDCD9D9FF, 0x85561600),
+        /* 3  */ MuseumRowColor(0xFFA030FF, 0x783A0000),
+        /* 4  */ MuseumRowColor(0x3667CAFF, 0x04007800),
+        /* 5  */ MuseumRowColor(0xCECACAFF, 0x82393900),
+        /* 6  */ MuseumRowColor(0xEB4040FF, 0x4F000000),
+        /* 7  */ MuseumRowColor(0x9A43B7FF, 0x0F013F00),
+        /* 8  */ MuseumRowColor(0xAFAFAFFF, 0x284D2F00),
+        /* 9  */ MuseumRowColor(0x2BA820FF, 0x013F0D00),
+        /* 10 */ MuseumRowColor(0x2BA820FF, 0x013F0D00),
+        /* 11 */ MuseumRowColor(0x2BA820FF, 0x013F0D00),
+        /* 12 */ MuseumRowColor(0x2BA820FF, 0x013F0D00),
+        /* 13 */ MuseumRowColor(0x2BA820FF, 0x013F0D00),
+        /* 14 */ MuseumRowColor(0x2BA820FF, 0x013F0D00),
+        /* 15 */ MuseumRowColor(0x2BA820FF, 0x013F0D00),
+        /* 16 */ MuseumRowColor(0xFFCAEDFF, 0x7E3E9200),
+        /* 17 */ MuseumRowColor(0xB7ECE2FF, 0x2E818600),
+        /* 18 */ MuseumRowColor(0xECE5B7FF, 0xADAA0800),
+        /* 19 */ MuseumRowColor(0x8C8C8CFF, 0x503C5000),
+        /* 20 */ MuseumRowColor(0xF7F2B9FF, 0xAA943C00),
+        /* 21 */ MuseumRowColor(0xF7F2B9FF, 0xAA943C00),
+        /* 22 */ MuseumRowColor(0xF7F2B9FF, 0xAA943C00),
+        /* 23 */ MuseumRowColor(0x78500AFF, 0x643C3200),
+        /* 24 */ MuseumRowColor(0x78500AFF, 0x643C3200),
+        /* 25 */ MuseumRowColor(0x78500AFF, 0x643C3200),
+        /* 26 */ MuseumRowColor(0x78500AFF, 0x643C3200),
+        /* 27 */ MuseumRowColor(0x78500AFF, 0x643C3200),
+        /* 28 */ MuseumRowColor(0x78500AFF, 0x643C3200),
     };
 
     // see section F5.1.35 in the arm A-profile reference manual
@@ -94,7 +92,7 @@ namespace Megamix::Patches {
 
         auto PushNewRows = [&]() {
             extraMuseumRows.emplace_back(newRowIds, "", 0, 0);
-            extraMuseumRowColors.emplace_back(rgba(0x424242ff), rgba(0x00000000));
+            extraMuseumRowColors.emplace_back(0x424242ff, 0x00000000);
 
             newRowIds = { 0x101, 0x101, 0x101, 0x101, 0x101 };
             newRowLength = 0;

--- a/src/Megamix/Region.cpp
+++ b/src/Megamix/Region.cpp
@@ -101,6 +101,20 @@ namespace Region {
         }
     }
 
+    u32 MuseumRowsColorsInitFunc() {
+        switch (region) {
+            case US:
+                return 0x38de58;
+
+            // TODO:
+            case EU:
+            case KR:
+            case JP:
+
+            default: return {};
+        }
+    }
+
     std::vector<u32> MuseumRowsColorsAddresses() {
         switch (region) {
             case US:


### PR DESCRIPTION
At patch time generate extra rows based on `config->tickflows`